### PR TITLE
Atualização de clausura para closure

### DIFF
--- a/WORDREFERENCE.md
+++ b/WORDREFERENCE.md
@@ -72,7 +72,7 @@
 
 #### C
 
-* Closure: Clausura (vide [(#91](https://github.com/cezaraugusto/You-Dont-Know-JS/issues/91#issuecomment-222319503))
+* Closure: Closure (vide [(#91](https://github.com/cezaraugusto/You-Dont-Know-JS/issues/91#issuecomment-222319503))
 * Coercion: Coerção
 * Compound Assignment: Atribuição com Operação
 * Compound Conditionals: Instrução Condicional


### PR DESCRIPTION
Atualização do termo `clausura` para **_`closure`_** conforme discutido em [(#91](https://github.com/cezaraugusto/You-Dont-Know-JS/issues/91#issuecomment-222319503)).